### PR TITLE
Fixed Segmentation Fault error

### DIFF
--- a/ADKafka/ADKafkaApp/Db/ADKafka.template
+++ b/ADKafka/ADKafkaApp/Db/ADKafka.template
@@ -66,7 +66,6 @@ record(mbbo, "$(P)$(R)StartMessageOffset") #Multi bit binary input
    field(TWVL, "2")
    field(THST, "End")
    field(THVL, "3")
-   field(SCAN, "I/O Intr")
 }
 
 record(stringin, "$(P)$(R)ConnectionMessage_RBV")


### PR DESCRIPTION
mbbo record shouldn't have field(SCAN, "I/O Intr"), It was causing Segmentation fault (core dumped) error in runtime.